### PR TITLE
targets for each station

### DIFF
--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -1,15 +1,8 @@
 
-make_table <- function(site_data_dir){
-  file_names = dir(site_data_dir)
-  m5sums = as.vector(md5sum(site_data_dir))
-  df = data.frame('filename' = file_names, 'm5sums'=m5sums)
-  return(df)
-}
-
-
-combine_csvs <- function(input_data_table, out_dir){
+combine_csvs <- function(input_dir){
   # loop through downloaded files
-  download_files <- file.path(out_dir, input_data_table$filename)
+  download_files <- dir(input_dir)
+  download_files <- file.path(input_dir, download_files)
   data_out <- data.frame(agency_cd = c(), site_no = c(), dateTime = c(), 
                          X_00010_00000 = c(), X_00010_00000_cd = c(), tz_cd = c())
   for (download_file in download_files){

--- a/2_process/src/process_and_style.R
+++ b/2_process/src/process_and_style.R
@@ -17,3 +17,10 @@ annotate_data <- function(site_data_clean, site_filename){
 style_data <- function(site_data_annotated){
   mutate(site_data_annotated, station_name = as.factor(station_name))
 }
+
+process_annotate_style <- function(site_data, site_info_file){
+  processed = process_data(site_data)
+  annotated = annotate_data(processed, site_info_file)
+  styled = style_data(annotated)
+  return (styled)
+}

--- a/remake.yml
+++ b/remake.yml
@@ -10,13 +10,35 @@ packages:
   - readr
   - stringr
   - purrr
+  - tools
 
 targets:
   all:
     depends: 3_visualize/out/figure_1.png
 
+  # download all the data
+  1_fetch/out/site_data/nwis_01427207_data.csv:
+    command: download_nwis_site_data(filepath=target_name)
+  1_fetch/out/site_data/nwis_01432160_data.csv:
+    command: download_nwis_site_data(filepath=target_name)
+  1_fetch/out/site_data/nwis_01435000_data.csv:
+    command: download_nwis_site_data(filepath=target_name)
+  1_fetch/out/site_data/nwis_01436690_data.csv:
+    command: download_nwis_site_data(filepath=target_name)
+  1_fetch/out/site_data/nwis_01466500_data.csv:
+    command: download_nwis_site_data(filepath=target_name)
+
+  input_data_table:
+    command: make_table('1_fetch/out/site_data')
+    depends:
+        - "1_fetch/out/site_data/nwis_01427207_data.csv"
+        - "1_fetch/out/site_data/nwis_01432160_data.csv"
+        - "1_fetch/out/site_data/nwis_01435000_data.csv"
+        - "1_fetch/out/site_data/nwis_01436690_data.csv"
+        - "1_fetch/out/site_data/nwis_01466500_data.csv"
+
   site_data:
-    command: download_nwis_data()
+    command: combine_csvs(input_data_table, I("1_fetch/out/site_data"))
   
   1_fetch/out/site_info.csv:
     command: nwis_site_info(fileout = '1_fetch/out/site_info.csv', site_data)

--- a/remake.yml
+++ b/remake.yml
@@ -28,30 +28,20 @@ targets:
   1_fetch/out/site_data/nwis_01466500_data.csv:
     command: download_nwis_site_data(filepath=target_name)
 
-  input_data_table:
-    command: make_table('1_fetch/out/site_data')
+  site_data:
+    command: combine_csvs("1_fetch/out/site_data")
     depends:
         - "1_fetch/out/site_data/nwis_01427207_data.csv"
         - "1_fetch/out/site_data/nwis_01432160_data.csv"
         - "1_fetch/out/site_data/nwis_01435000_data.csv"
         - "1_fetch/out/site_data/nwis_01436690_data.csv"
         - "1_fetch/out/site_data/nwis_01466500_data.csv"
-
-  site_data:
-    command: combine_csvs(input_data_table, I("1_fetch/out/site_data"))
   
   1_fetch/out/site_info.csv:
-    command: nwis_site_info(fileout = '1_fetch/out/site_info.csv', site_data)
+    command: nwis_site_info(fileout = target_name, site_data = site_data)
 
-  site_data_clean:
-    command: process_data(site_data)
-
-  site_data_annotated:
-    command: annotate_data(site_data_clean, site_filename = '1_fetch/out/site_info.csv')
-
-  site_data_styled:
-    command: style_data(site_data_annotated)	
+  site_data_prepped:
+    command: process_annotate_style(site_data, site_info_file = '1_fetch/out/site_info.csv')	
 
   3_visualize/out/figure_1.png:
-    command: plot_nwis_timeseries(fileout = '3_visualize/out/figure_1.png', 
-      site_data_styled)  
+    command: plot_nwis_timeseries(fileout = target_name, site_data_styled = site_data_prepped)  


### PR DESCRIPTION
I think it's better than it used to be, but I still don't like it. I don't know how to make a lot of targets without explictly writing them out. I also didn't know how to make the subsequent steps in the pipeline depend on that list of new targets.

In snakemake I would just do this:
```
all_stations = ["01427207", "01432160", "01435000", "01436690", "01466500"]
...

rule pull_one_station:
    output:
        "1_fetch/out/site_data/nwis_{site_code}_data.csv"
    run:
        download_nwis_site_data({output[0]})

rule combine_stations:
    input:
        expand("1_fetch/out/site_data/nwis_{site_code}_data.csv", site_code=all_stations)
    output:
        "1_fetch/out/combined_stations.csv"        
    run:
        combine({input})
...
```
but I don't know how to do that in scipiper.
